### PR TITLE
fix(bls): keep common series before FTS cap

### DIFF
--- a/src/services/bls-catalog/bls-catalog-service.ts
+++ b/src/services/bls-catalog/bls-catalog-service.ts
@@ -83,9 +83,11 @@ const OES_SURVEY_ABBR = 'oe';
 const COMMON_SERIES: Record<string, string> = {
   LNS14000000: 'civilian unemployment rate seasonally adjusted',
   CES0000000001: 'total nonfarm payrolls seasonally adjusted',
-  CUUR0000SA0: 'cpi-u all items u.s. city average not seasonally adjusted',
-  CUSR0000SA0: 'cpi-u all items u.s. city average seasonally adjusted',
-  WPUFD49104: 'ppi finished goods',
+  CUUR0000SA0:
+    'consumer price index cpi cpi-u all items u.s. city average all urban consumers not seasonally adjusted',
+  CUSR0000SA0:
+    'consumer price index cpi cpi-u all items u.s. city average all urban consumers seasonally adjusted',
+  WPUFD49104: 'producer price index ppi finished goods',
   JTS000000000000000JOL: 'jolts job openings all industries',
   LNS11300000: 'labor force participation rate',
   LNS12000000: 'civilian employment level',
@@ -393,11 +395,15 @@ export class BlsCatalogService {
     const seasonFilter = input.seasonal_adjustment;
 
     // Candidate set: an exact-id lookup (guarantees the precise SeriesID is in
-    // play) unioned with the FTS5 matches, deduped by series id.
+    // play), known headline/common series (so bespoke boosts are not lost to the
+    // FTS candidate cap), and the FTS5 matches, deduped by series id.
     const candidates = new Map<string, CatalogSeries>();
 
     const exact = await this.store.getByIds([input.query.trim().toUpperCase()]);
     for (const row of exact) candidates.set(row.series_id as string, toCatalog(row));
+
+    const commonRows = await this.store.getByIds(Object.keys(COMMON_SERIES));
+    for (const row of commonRows) candidates.set(row.series_id as string, toCatalog(row));
 
     const tokens = query.match(/[a-z0-9]+/gi) ?? [];
     if (tokens.length > 0) {

--- a/tests/services/bls-catalog/bls-catalog-service.test.ts
+++ b/tests/services/bls-catalog/bls-catalog-service.test.ts
@@ -234,6 +234,35 @@ describe('BlsCatalogService.search', () => {
     });
     expect(result.series[0]!.seriesId).toBe('LNS14000000');
   });
+
+  it('keeps headline common series in play before applying the FTS candidate cap', async () => {
+    const genericMatches: CatalogSeries[] = Array.from({ length: 1_005 }, (_, i) => ({
+      seriesId: `TEST_CPI_DISTRACTOR_${String(i).padStart(4, '0')}`,
+      title: `Consumer Price Index distractor ${i}`,
+      surveyAbbr: 'CE',
+      seasonal: false,
+    }));
+    const headlineCpi: CatalogSeries = {
+      seriesId: 'CUUR0000SA0',
+      title: 'All items in U.S. city average, all urban consumers, not seasonally adjusted',
+      surveyAbbr: 'CU',
+      seasonal: false,
+      areaName: 'U.S. city average',
+      itemName: 'All items',
+    };
+    const svc = await seedAndLoad([...genericMatches, headlineCpi]);
+
+    const result = await svc.search({
+      query: 'consumer price index',
+      survey: undefined,
+      area: undefined,
+      seasonal_adjustment: undefined,
+      limit: 10,
+    });
+
+    expect(result.series.map((s) => s.seriesId)).toContain('CUUR0000SA0');
+    expect(result.series.findIndex((s) => s.seriesId === 'CUUR0000SA0')).toBeLessThan(3);
+  });
 });
 
 describe('BlsCatalogService state', () => {


### PR DESCRIPTION
## Summary
- Add headline/common BLS series to the candidate set before the FTS candidate cap is applied.
- Expand CPI/PPI common-series aliases so canonical queries like `consumer price index` and `CPI` score the headline series correctly.
- Add a regression test that reproduces `CUUR0000SA0` being dropped behind >1,000 higher-bm25 distractors.

## Test Plan
- [x] `bun test tests/services/bls-catalog/bls-catalog-service.test.ts`
- [x] `bun run devcheck`

Closes #35
